### PR TITLE
Bump `infection/infection` from `0.30.0` to `0.30.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "infection/infection": "~0.30.0",
+        "infection/infection": "~0.30.1",
         "mockery/mockery": "~1.6.12",
         "phpunit/phpunit": "~12.2.5",
         "symfony/var-dumper": "~7.3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb5d0d7dd838879aca49045d5325fc68",
+    "content-hash": "9ae61517fee085788b6f650cc11c33d3",
     "packages": [],
     "packages-dev": [
         {
@@ -2540,16 +2540,16 @@
         },
         {
             "name": "infection/infection",
-            "version": "0.30.0",
+            "version": "0.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/infection/infection.git",
-                "reference": "fa3be5667a312e108a81425660a847710cd36632"
+                "reference": "70cd94675f6372cf13962d9d52de86b02a909c09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infection/infection/zipball/fa3be5667a312e108a81425660a847710cd36632",
-                "reference": "fa3be5667a312e108a81425660a847710cd36632",
+                "url": "https://api.github.com/repos/infection/infection/zipball/70cd94675f6372cf13962d9d52de86b02a909c09",
+                "reference": "70cd94675f6372cf13962d9d52de86b02a909c09",
                 "shasum": ""
             },
             "require": {
@@ -2654,7 +2654,7 @@
             ],
             "support": {
                 "issues": "https://github.com/infection/infection/issues",
-                "source": "https://github.com/infection/infection/tree/0.30.0"
+                "source": "https://github.com/infection/infection/tree/0.30.1"
             },
             "funding": [
                 {
@@ -2666,7 +2666,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2025-07-02T22:08:45+00:00"
+            "time": "2025-07-03T22:10:25+00:00"
         },
         {
             "name": "infection/mutator",


### PR DESCRIPTION
Bumps `infection/infection` from `0.30.0` to `0.30.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`