### PR TITLE
Update ghostwriter/coding-standard to version dev-main#ecac8c6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -638,12 +638,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "f3eb328a44b318208f7c5e5f65a99d9ff6670852"
+                "reference": "ecac8c6c4623c773fd3ff7977d21a950ea31410c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/f3eb328a44b318208f7c5e5f65a99d9ff6670852",
-                "reference": "f3eb328a44b318208f7c5e5f65a99d9ff6670852",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/ecac8c6c4623c773fd3ff7977d21a950ea31410c",
+                "reference": "ecac8c6c4623c773fd3ff7977d21a950ea31410c",
                 "shasum": ""
             },
             "require": {
@@ -703,7 +703,7 @@
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.6.2",
                 "php": "~8.4.0 || ~8.5.0",
-                "phpunit/phpunit": "^12.4.4",
+                "phpunit/phpunit": "^12.4.5",
                 "symfony/process": "^8.0.0",
                 "symfony/var-dumper": "^8.0.0"
             },
@@ -819,7 +819,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-29T21:23:11+00:00"
+            "time": "2025-12-01T08:55:04+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#f3eb328` to `dev-main#ecac8c6`.

This pull request changes the following file(s): 

- Update `composer.lock`