### PR TITLE
Update ghostwriter/container to version 7.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "ghostwriter/container": "^6.1.1",
+        "ghostwriter/container": "^7.0.0",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.7",
         "symfony/var-dumper": "^8.0.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f156e8f8530ef005cc719bd5f2bd662a",
+    "content-hash": "9b311b0bb7efcaad311477e71241672f",
     "packages": [],
     "packages-dev": [
         {
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "75e0a8e06e1e271b384141143cdce701de48d3ef"
+                "reference": "42659c01dc101851ef88c4c3491581a59743b36a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/75e0a8e06e1e271b384141143cdce701de48d3ef",
-                "reference": "75e0a8e06e1e271b384141143cdce701de48d3ef",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/42659c01dc101851ef88c4c3491581a59743b36a",
+                "reference": "42659c01dc101851ef88c4c3491581a59743b36a",
                 "shasum": ""
             },
             "require": {
@@ -69,7 +69,7 @@
                 "ext-zlib": "*",
                 "mockery/mockery": "^1.6.12",
                 "php": "~8.4.0 || ~8.5.0",
-                "phpunit/phpunit": "^13.1.6",
+                "phpunit/phpunit": "^13.1.7",
                 "symfony/var-dumper": "^8.0.8"
             },
             "conflict": {
@@ -132,20 +132,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-17T14:32:36+00:00"
+            "time": "2026-04-19T01:32:06+00:00"
         },
         {
             "name": "ghostwriter/container",
-            "version": "6.1.1",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/container.git",
-                "reference": "478b61f4b95ea95969e6552f29d539c81fed10d6"
+                "reference": "1931a1175deb24d0e5901a689054be8227144b3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/container/zipball/478b61f4b95ea95969e6552f29d539c81fed10d6",
-                "reference": "478b61f4b95ea95969e6552f29d539c81fed10d6",
+                "url": "https://api.github.com/repos/ghostwriter/container/zipball/1931a1175deb24d0e5901a689054be8227144b3d",
+                "reference": "1931a1175deb24d0e5901a689054be8227144b3d",
                 "shasum": ""
             },
             "require": {
@@ -159,7 +159,7 @@
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^13.1.3",
+                "phpunit/phpunit": "^13.1.7",
                 "symfony/var-dumper": "^8.0.8"
             },
             "type": "library",
@@ -211,7 +211,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-14T14:00:13+00:00"
+            "time": "2026-04-20T15:01:26+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/container` dependency from `6.1.1` to `7.0.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`