### PR TITLE
Update boundwize/structarmed to version 0.5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.5.0",
+        "boundwize/structarmed": "^0.5.1",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a125dadec4d2806618d816501785000e",
+    "content-hash": "cf068c85f557e823a960129185827dd9",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "cd626ff2604e98e045427b7d1a6493632a351156"
+                "reference": "9cae458f50d3633a33f59c1382bcc8cbee17639d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/cd626ff2604e98e045427b7d1a6493632a351156",
-                "reference": "cd626ff2604e98e045427b7d1a6493632a351156",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/9cae458f50d3633a33f59c1382bcc8cbee17639d",
+                "reference": "9cae458f50d3633a33f59c1382bcc8cbee17639d",
                 "shasum": ""
             },
             "require": {
@@ -66,7 +66,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.5.0"
+                "source": "https://github.com/boundwize/structarmed/tree/0.5.1"
             },
             "funding": [
                 {
@@ -74,7 +74,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-13T01:30:23+00:00"
+            "time": "2026-05-13T16:56:25+00:00"
         },
         {
             "name": "ghostwriter/coding-standard",
@@ -82,16 +82,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "0a5bee924aa1414cb71091b79b241dcb42667c0e"
+                "reference": "2055bbfc6195ae0171f3ed46f328ccd44a54d226"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/0a5bee924aa1414cb71091b79b241dcb42667c0e",
-                "reference": "0a5bee924aa1414cb71091b79b241dcb42667c0e",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/2055bbfc6195ae0171f3ed46f328ccd44a54d226",
+                "reference": "2055bbfc6195ae0171f3ed46f328ccd44a54d226",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.5.0",
+                "boundwize/structarmed": "^0.5.1",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -202,7 +202,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-13T06:18:35+00:00"
+            "time": "2026-05-13T17:09:25+00:00"
         },
         {
             "name": "ghostwriter/container",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.5.0` to `0.5.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`