### PR TITLE
Update boundwize/structarmed to version 0.6.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.4",
+        "boundwize/structarmed": "^0.6.5",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f61f44021315c9985f412326f1aad7c",
+    "content-hash": "ae9237630214913cb720a0fd3a16fbfe",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.4",
+            "version": "0.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "8d630745f6e26f9c4c4d8886da913ba5264ff47b"
+                "reference": "3a1caa93b368e1bb6fb7c4344dc27eff2db9ff66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/8d630745f6e26f9c4c4d8886da913ba5264ff47b",
-                "reference": "8d630745f6e26f9c4c4d8886da913ba5264ff47b",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/3a1caa93b368e1bb6fb7c4344dc27eff2db9ff66",
+                "reference": "3a1caa93b368e1bb6fb7c4344dc27eff2db9ff66",
                 "shasum": ""
             },
             "require": {
@@ -67,7 +67,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.4"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.5"
             },
             "funding": [
                 {
@@ -75,7 +75,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-16T17:20:29+00:00"
+            "time": "2026-05-17T03:44:56+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -144,16 +144,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "2c20193be3316dcd85999c946d35b9051576ae97"
+                "reference": "55a42647194a75dd28eba5095c3f329de89a0306"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/2c20193be3316dcd85999c946d35b9051576ae97",
-                "reference": "2c20193be3316dcd85999c946d35b9051576ae97",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/55a42647194a75dd28eba5095c3f329de89a0306",
+                "reference": "55a42647194a75dd28eba5095c3f329de89a0306",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.6.4",
+                "boundwize/structarmed": "^0.6.5",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -264,7 +264,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-16T17:56:23+00:00"
+            "time": "2026-05-17T03:54:31+00:00"
         },
         {
             "name": "ghostwriter/container",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.4` to `0.6.5`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`