### PR TITLE
Update boundwize/structarmed to version 0.6.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.6",
+        "boundwize/structarmed": "^0.6.7",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa18ba44237ed8c946c7a61faa8bd6f8",
+    "content-hash": "a3b61f00e481f8a4ec7fdf7209dcb83f",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.6.6",
+            "version": "0.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "7c8221644ea04f476d328a29ea4d9bbce9933ce8"
+                "reference": "6fe4bc42f1434a24c4d1dcefdc1116f14dec67b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/7c8221644ea04f476d328a29ea4d9bbce9933ce8",
-                "reference": "7c8221644ea04f476d328a29ea4d9bbce9933ce8",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/6fe4bc42f1434a24c4d1dcefdc1116f14dec67b4",
+                "reference": "6fe4bc42f1434a24c4d1dcefdc1116f14dec67b4",
                 "shasum": ""
             },
             "require": {
@@ -67,7 +67,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.6.6"
+                "source": "https://github.com/boundwize/structarmed/tree/0.6.7"
             },
             "funding": [
                 {
@@ -75,7 +75,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-17T23:55:12+00:00"
+            "time": "2026-05-18T12:23:19+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.6` to `0.6.7`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`