### PR TITLE
Update ghostwriter/testify to version 0.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.2",
         "ghostwriter/phpunit-assertions": "^0.1.0",
-        "ghostwriter/testify": "^0.1.1",
+        "ghostwriter/testify": "^0.1.2",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.12",
         "symfony/var-dumper": "^8.0.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ea86691f5db4d38c57b389a8300b791",
+    "content-hash": "eb84ba9a618d8585bb4a3efd16d70f7d",
     "packages": [],
     "packages-dev": [
         {
@@ -237,16 +237,15 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "33f2332341fecf8f3aaa266cd5862354a94d2c3a"
+                "reference": "ca8d6f740a7cd548808ae69f7b5fa4550caeb871"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/33f2332341fecf8f3aaa266cd5862354a94d2c3a",
-                "reference": "33f2332341fecf8f3aaa266cd5862354a94d2c3a",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/ca8d6f740a7cd548808ae69f7b5fa4550caeb871",
+                "reference": "ca8d6f740a7cd548808ae69f7b5fa4550caeb871",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.7.12",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -292,10 +291,7 @@
                 "ext-zend-opcache": "*",
                 "ext-zip": "*",
                 "ext-zlib": "*",
-                "mockery/mockery": "^1.6.12",
-                "php": "~8.4.0 || ~8.5.0",
-                "phpunit/phpunit": "^13.1.12",
-                "symfony/var-dumper": "^8.0.8"
+                "php": "~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "pestphp/pest": "*"
@@ -357,7 +353,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T18:12:02+00:00"
+            "time": "2026-05-27T19:35:28+00:00"
         },
         {
             "name": "ghostwriter/config",
@@ -829,16 +825,16 @@
         },
         {
             "name": "ghostwriter/testify",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/testify.git",
-                "reference": "bafc11a8a5d83e4de796e83b5c206b9fb4b72609"
+                "reference": "178499d1483b48124703ae76d304370be21dcf8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/testify/zipball/bafc11a8a5d83e4de796e83b5c206b9fb4b72609",
-                "reference": "bafc11a8a5d83e4de796e83b5c206b9fb4b72609",
+                "url": "https://api.github.com/repos/ghostwriter/testify/zipball/178499d1483b48124703ae76d304370be21dcf8b",
+                "reference": "178499d1483b48124703ae76d304370be21dcf8b",
                 "shasum": ""
             },
             "require": {
@@ -846,17 +842,18 @@
                 "ghostwriter/case-converter": "^2.2.2",
                 "ghostwriter/config": "^2.1.3",
                 "ghostwriter/console": "^0.2.3",
-                "ghostwriter/container": "^7.0.1",
+                "ghostwriter/container": "^7.0.2",
                 "ghostwriter/event-dispatcher": "^6.1.1",
                 "ghostwriter/filesystem": "^0.2.0",
                 "nikic/php-parser": "^5.7.0",
                 "php": "~8.4.0 || ~8.5.0"
             },
             "require-dev": {
+                "boundwize/structarmed": "^0.7.12",
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^13.1.8",
+                "phpunit/phpunit": "^13.1.12",
                 "symfony/var-dumper": "^8.0.8"
             },
             "bin": [
@@ -913,7 +910,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-07T03:08:20+00:00"
+            "time": "2026-05-27T08:34:49+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/testify` dependency from `0.1.1` to `0.1.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`