### PR TITLE
Update `boundwize/structarmed` to version `0.11.3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.11.1",
+        "boundwize/structarmed": "^0.11.3",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.2",
         "ghostwriter/phpunit-assertions": "^0.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fffb5b01942ca7f98b3c377d5ca3f2c1",
+    "content-hash": "5d7b406f102c677e12a3e2969ffdca2c",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.11.1",
+            "version": "0.11.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "6188459db463c671891b95df14fd97ad62ae56a4"
+                "reference": "42a2520eda670609d701f9e6704b7d31d8d8b697"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/6188459db463c671891b95df14fd97ad62ae56a4",
-                "reference": "6188459db463c671891b95df14fd97ad62ae56a4",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/42a2520eda670609d701f9e6704b7d31d8d8b697",
+                "reference": "42a2520eda670609d701f9e6704b7d31d8d8b697",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.11.1"
+                "source": "https://github.com/boundwize/structarmed/tree/0.11.3"
             },
             "funding": [
                 {
@@ -79,7 +79,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-04T13:20:47+00:00"
+            "time": "2026-06-04T16:05:09+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the [`boundwize/structarmed`](https://packagist.org/packages/boundwize/structarmed) dependency from `0.11.1` to `0.11.3`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`